### PR TITLE
Bump minimal iOS deployment target to fix Release build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ iOS 15 share play API in react-native
 yarn add react-native-shareplay
 ```
 
-And go to Xcode Capabilities and enable "Group Activities"
+* Go to Xcode Capabilities and enable "Group Activities"
+* Make sure your iOS Deployment target is 11.0 (`IPHONEOS_DEPLOYMENT_TARGET` in `project.pbxproj` and `platform :ios, '11.0'` in your `Podfile`)
 
 ## Example
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '10.0'
+platform :ios, '11.0'
 
 target 'SharePlayExample' do
   config = use_native_modules!
@@ -18,4 +18,15 @@ target 'SharePlayExample' do
   # post_install do |installer|
   #  flipper_post_install(installer)
   # end
+
+  post_install do |installer|
+   installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+     config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0'
+    end
+   end
+  end
+
+  # add this if you enable Flipper
+  # `sed -i -e  $'s/__IPHONE_10_0/__IPHONE_12_0/' #{installer.sandbox.root}/RCT-Folly/folly/portability/Time.h`
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -185,7 +185,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-shareplay (0.3.6):
+  - react-native-shareplay (0.6.1):
     - React-Core
   - React-RCTActionSheet (0.63.4):
     - React-Core/RCTActionSheetHeaders (= 0.63.4)
@@ -357,7 +357,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-shareplay: 23200a51c422ed06a0283db03b54e148128415fe
+  react-native-shareplay: 8213819f71a666abb3eb5a7cbee75bea5c379567
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b
   React-RCTBlob: a97d378b527740cc667e03ebfa183a75231ab0f0
@@ -370,6 +370,6 @@ SPEC CHECKSUMS:
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
   Yoga: 4bd86afe9883422a7c4028c00e34790f560923d6
 
-PODFILE CHECKSUM: 501e20b4f7e72a08ec610185f039784c684e42a6
+PODFILE CHECKSUM: 3532c47a063d896526e56ca8e6feb0179e0e44c8
 
 COCOAPODS: 1.11.2

--- a/example/ios/SharePlayExample.xcodeproj/project.pbxproj
+++ b/example/ios/SharePlayExample.xcodeproj/project.pbxproj
@@ -505,7 +505,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SharePlayExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -524,7 +524,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = SharePlayExampleTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -548,6 +548,7 @@
 				DEVELOPMENT_TEAM = 7CRYNR44B3;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = SharePlayExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -572,6 +573,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 7CRYNR44B3;
 				INFOPLIST_FILE = SharePlayExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -738,7 +740,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
@@ -791,7 +793,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",

--- a/react-native-shareplay.podspec
+++ b/react-native-shareplay.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "11.0" }
   s.source       = { :git => "https://github.com/popshoplive/react-native-shareplay.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
* Necessary to make it work on old RN versions (tested on 0.64)
* You might need to do [this](https://github.com/facebook/react-native/issues/32253#issuecomment-925747908) in your project when bumping iOS deployment target (unrelated to this lib) 
* In this repo's example it doesn't compile yet but this is not related
* Fixes #2 